### PR TITLE
Remove mongo-c-driver legacy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "mongo-c-driver"]
-	path = mongo-c-driver
-	url = https://github.com/mongodb/mongo-c-driver-legacy.git

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,5 @@ git clone https://github.com/nginx/nginx.git
 git clone https://github.com/chaopeng/gridfs-nginx-plugin.git
 
 cd gridfs-nginx-plugin
-git submodule init
-git submodule update
+git clone https://github.com/eagleas/mongo-c-driver.git
 ./build.sh

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -2,7 +2,7 @@
 # Tengine dockerfile base CentOS:latest
 # plugins:
 #   - nginx-md5
-#   - nginx-gridfs  
+#   - nginx-gridfs
 
 FROM centos:latest
 MAINTAINER Chao<chaopeng@chaopeng.me>
@@ -16,8 +16,7 @@ RUN git clone https://github.com/alibaba/tengine.git
 # nginx-gridfs
 RUN git clone https://github.com/chaopeng/gridfs-nginx-plugin.git
 RUN cd gridfs-nginx-plugin && \
-  git submodule init && \
-  git submodule update
+  git clone https://github.com/eagleas/mongo-c-driver.git
 
 RUN cd tengine && \
 ./configure  --with-cc-opt="-Wno-sign-compare -Wno-unused-variable" \
@@ -30,9 +29,7 @@ RUN cd tengine && \
 make -j8 && \
 make install
 
-
 CMD ["/usr/local/nginx/sbin/nginx"]
 
 EXPOSE 80
 EXPOSE 443
-

--- a/ngx_http_gridfs_module.c
+++ b/ngx_http_gridfs_module.c
@@ -455,7 +455,7 @@ static ngx_int_t ngx_http_mongo_authenticate(ngx_log_t *log, ngx_http_gridfs_loc
     test = (char*)malloc( gridfs_loc_conf->db.len + sizeof(".test"));
     ngx_cpystrn((u_char*)test, (u_char*)gridfs_loc_conf->db.data, gridfs_loc_conf->db.len+1);
     ngx_cpystrn((u_char*)(test+gridfs_loc_conf->db.len),(u_char*)".test", sizeof(".test"));
-    bson_init_empty(&empty);
+    bson_empty(&empty);
     cursor = mongo_find(&mongo_conn->conn, test, &empty, NULL, 0, 0, 0);
     error =  mongo_cmd_get_last_error(&mongo_conn->conn, (char*)gridfs_loc_conf->db.data, NULL);
     free(test);


### PR DESCRIPTION
The current mongo-c-driver seems to be faulty or not compatible with some versions of mongodb (>2.6.8)

This PR will remove the legacy mongo-c-driver and use a working version instead.
